### PR TITLE
Update rlib version from 3.9.0 to 3.9.1

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -10,7 +10,7 @@ fabric = "0.133.13+1.21.9"
 fabrickotlin = "1.13.3+kotlin.2.1.21"
 hypixelapi = "1.0.1+build.1+mc1.21"
 olympus = "1.6.0"
-rlib = "3.9.0"
+rlib = "3.9.1"
 
 # Dev Dependencies
 devauth = "1.2.1"


### PR DESCRIPTION
Needed for targeted block outline fix in 1.21.10

Haven't tested if it builds, check CI

New release in Modrinth needed to get the bundled dep updated without using an actions build or explicit non bundled rlib.