### PR TITLE
Use dedicated IO thread pool to avoid contention with Skyblocker

### DIFF
--- a/src/main/kotlin/tech/thatgravyboat/rewardclaim/Utils.kt
+++ b/src/main/kotlin/tech/thatgravyboat/rewardclaim/Utils.kt
@@ -5,8 +5,13 @@ import earth.terrarium.olympus.client.components.compound.LayoutWidget
 import earth.terrarium.olympus.client.pipelines.RoundedRectangle
 import net.minecraft.client.Minecraft
 import net.minecraft.client.gui.GuiGraphics
+import java.util.concurrent.Executors
 import java.util.concurrent.TimeUnit
 import kotlin.time.Duration
+
+internal val IO_EXECUTOR = Executors.newFixedThreadPool(Runtime.getRuntime().availableProcessors().coerceAtLeast(1) * 2) { runnable ->
+    Thread(runnable, "RewardClaim-IO").apply { isDaemon = true }
+}
 
 val mc: Minecraft get() = Minecraft.getInstance()
 

--- a/src/main/kotlin/tech/thatgravyboat/rewardclaim/data/DataManager.kt
+++ b/src/main/kotlin/tech/thatgravyboat/rewardclaim/data/DataManager.kt
@@ -1,5 +1,6 @@
 package tech.thatgravyboat.rewardclaim.data
 
+import tech.thatgravyboat.rewardclaim.IO_EXECUTOR
 import tech.thatgravyboat.rewardclaim.remote.RemoteData
 import java.net.CookieManager
 import java.net.URI
@@ -22,7 +23,7 @@ object DataManager {
         .cookieHandler(cookies)
         .build()
 
-    fun get(id: String): CompletableFuture<RewardState> = CompletableFuture.supplyAsync {
+    fun get(id: String): CompletableFuture<RewardState> = CompletableFuture.supplyAsync({
         val request = HttpRequest.newBuilder(URI.create("$URL$id"))
             .GET()
             .version(HttpClient.Version.HTTP_2)
@@ -36,9 +37,9 @@ object DataManager {
         val i18n = I18N_REGEX.find(output) ?: error("Translations not found in response for ID: $id")
 
         RewardState.get(security, data, i18n)
-    }
+    }, IO_EXECUTOR)
 
-    fun claim(state: RewardState, reward: Reward): CompletableFuture<Void> = CompletableFuture.runAsync {
+    fun claim(state: RewardState, reward: Reward): CompletableFuture<Void> = CompletableFuture.runAsync({
         val data = state.data
         val selected = data.rewards.indexOfFirst { it == reward }
         val url = "$CLAIM_URL?option=$selected&id=${data.id}&activeAd=${data.activeAd}&_csrf=${state.token}&watchedFallback=false"
@@ -58,5 +59,5 @@ object DataManager {
                 "response: ${res.body()}"
             )
         }
-    }
+    }, IO_EXECUTOR)
 }

--- a/src/main/kotlin/tech/thatgravyboat/rewardclaim/remote/RemoteData.kt
+++ b/src/main/kotlin/tech/thatgravyboat/rewardclaim/remote/RemoteData.kt
@@ -3,6 +3,7 @@ package tech.thatgravyboat.rewardclaim.remote
 import com.mojang.serialization.JsonOps
 import com.teamresourceful.resourcefullib.common.utils.WebUtils
 import net.minecraft.util.GsonHelper
+import tech.thatgravyboat.rewardclaim.IO_EXECUTOR
 import java.net.URI
 import java.util.concurrent.CompletableFuture
 
@@ -26,11 +27,11 @@ data class RemoteData(
         private var instance: RemoteData? = null
 
         init {
-            CompletableFuture.runAsync {
+            CompletableFuture.runAsync({
                 val data = WebUtils.get("https://raw.githubusercontent.com/ThatGravyBoat/RewardClaim/master/data.json") ?: error("Failed to fetch remote data.")
                 val json = GsonHelper.parse(data)
                 instance = RemoteCodec.CODEC.parse(JsonOps.INSTANCE, json).orThrow
-            }
+            }, IO_EXECUTOR)
         }
 
         fun get(): RemoteData {


### PR DESCRIPTION
The root cause of #15 is that `CompletableFuture.supplyAsync` / `runAsync` without an explicit executor dispatches work to `ForkJoinPool.commonPool()`, which is shared across the entire JVM. When Skyblocker is installed it also hammers the common pool (helmet texture loading, etc.), so RewardClaim's HTTP calls—`DataManager.get()`, `DataManager.claim()`, and the `RemoteData` init block—end up queued behind Skyblocker's tasks. Under heavy load this manifests as multi-second stalls when a player tries to claim a reward.

The change introduces a dedicated `IO_EXECUTOR` in `Utils.kt`: a fixed-size daemon thread pool (cores × 2, minimum 2 threads) whose threads are named `RewardClaim-IO` for easy identification in thread dumps. All three `CompletableFuture` call sites in `DataManager.kt` (`get` and `claim`) and `RemoteData.kt` (the static init fetch of `data.json`) now pass this executor explicitly, so reward-related I/O is fully isolated from whatever else the common pool is doing. The pool size follows the standard heuristic for I/O-bound work, and daemon threads ensure the pool won't prevent the game from shutting down cleanly.

I verified locally by loading into a Hypixel lobby with both Skyblocker and RewardClaim installed, triggering a reward claim while Skyblocker was still initializing—rewards loaded within a couple of seconds instead of hanging indefinitely, and the `RewardClaim-IO` threads showed up correctly in a thread dump with no exceptions or unexpected behavior on shutdown.

Closes https://github.com/meowdding/RewardClaim/issues/15